### PR TITLE
GitHub Actions Deprecation Remediation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Execute this action
       uses: BjornLuG/substitute-string-action@v1.0.0
       id: sub


### PR DESCRIPTION
Remediates issues involving node 12, set-ouput and outdated versions of multiple actions references (ex. hashicorp/setup-terraform@v1)